### PR TITLE
fix: downgrade AutoMapper and AutoMapper.Extensions to earlier versions

### DIFF
--- a/apps/IdentityService/IdentityService.csproj
+++ b/apps/IdentityService/IdentityService.csproj
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="12.0.1" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+        <PackageReference Include="AutoMapper" Version="10.1.1" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
         <PackageReference Include="IdentityServer4" Version="4.1.2" />


### PR DESCRIPTION
* Downgraded AutoMapper from version 12.0.1 to version 10.1.1, and AutoMapper.Extensions.Microsoft.DependencyInjection from version 12.0.1 to version 8.1.1 in IdentityService project. This change was made to resolve compatibility issues with other packages in the project.

Closes #97